### PR TITLE
Use a truecolor terminal shell by default

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -200,8 +200,12 @@ func (c *sshClient) bridgeWSAndSSH() {
 	}
 	defer c.sessIn.Close()
 
-	if err := c.sess.RequestPty("xterm", wdSize.High, wdSize.Width, terminalModes); err != nil {
+	if err := c.sess.RequestPty("xterm-256color", wdSize.High, wdSize.Width, terminalModes); err != nil {
 		log.Println("bridgeWSAndSSH: session.RequestPty:", err)
+		return
+	}
+	if err := c.sess.Setenv("COLORTERM", "truecolor"); err != nil {
+		log.Println("bridgeWSAndSSH: session.Setenv:", err)
 		return
 	}
 	if err := c.sess.Shell(); err != nil {


### PR DESCRIPTION
Like so:

![lolcat](https://user-images.githubusercontent.com/10364051/202303292-12947f10-d595-4321-a5f2-68f0c56527de.png)

See <https://github.com/busyloop/lolcat> for demo (or [charm.sh](https://charm.sh/))

Closes #5 